### PR TITLE
Feature/be open api vworld search

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,10 +24,11 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.hibernate:hibernate-spatial:6.5.2.Final'
 	compileOnly 'org.projectlombok:lombok'
-//	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/src/main/java/com/jsj/backend/BackendApplication.java
+++ b/backend/src/main/java/com/jsj/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.jsj.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/jsj/backend/search/SearchController.java
+++ b/backend/src/main/java/com/jsj/backend/search/SearchController.java
@@ -46,4 +46,32 @@ public class SearchController {
         // SearchService를 사용하여 페이지 번호를 포함한 주소 검색 결과를 얻어와서 클라이언트에 반환
         return ResponseEntity.ok(service.getAddressWithCurrentPage(keyword, currentPage));
     }
+
+    /**
+     * 주어진 쿼리로 포인트를 검색하는 HTTP GET 요청을 처리합니다.
+     *
+     * @param query 검색할 쿼리
+     * @return 검색 결과를 담고 있는 ResponseEntity 객체
+     */
+    @GetMapping("/point")
+    public ResponseEntity<?> getPoint(@RequestParam String query) {
+        // SearchService를 사용하여 포인트 검색 결과를 얻어와서 클라이언트에 반환
+        return ResponseEntity.ok(service.getPoint(query));
+    }
+
+    /**
+     * 주어진 쿼리와 페이지 번호로 포인트를 검색하는 HTTP GET 요청을 처리합니다.
+     *
+     * @param query 검색할 쿼리
+     * @param page 검색할 현재 페이지 번호
+     * @return 검색 결과를 담고 있는 ResponseEntity 객체
+     */
+    @GetMapping("/point-with-page")
+    public ResponseEntity<?> getPointWithPage(
+            @RequestParam String query,
+            @RequestParam Integer page
+    ) {
+        // SearchService를 사용하여 페이지 번호를 포함한 포인트 검색 결과를 얻어와서 클라이언트에 반환
+        return ResponseEntity.ok(service.getPointWithPage(query, page));
+    }
 }

--- a/backend/src/main/java/com/jsj/backend/search/SearchService.java
+++ b/backend/src/main/java/com/jsj/backend/search/SearchService.java
@@ -5,6 +5,7 @@ import com.jsj.backend.exception.InvalidInputException;
 import com.jsj.backend.search.juso.JusoApiClient;
 import com.jsj.backend.search.juso.JusoApiRequest;
 import com.jsj.backend.search.juso.JusoApiResponse;
+import com.jsj.backend.search.vworld.*;
 import com.jsj.backend.util.CleanInputUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,13 @@ public class SearchService {
     @Value("${api.juso.key}")
     private String confmKey; // 외부 설정 파일에서 주입받는 Juso API 키
     private final String RESULT_TYPE = "json"; // 결과 형식
+
+    private final VWorldSearchApiClient vWorldSearchApiClient;
+
+    @Value("${api.vworld.key}")
+    private String API_KEY_VWORLD; // 외부 설정 파일에서 주입받는 VWorld API 키
+
+    private final VWorldLogRepository vWorldLogRepository; // VWorld 로그 저장소
 
     /**
      * 주어진 키워드로 주소를 검색합니다.
@@ -93,5 +101,58 @@ public class SearchService {
                         .resultType(RESULT_TYPE)
                         .build()
         );
+    }
+
+    /**
+     * 주어진 쿼리로 포인트를 검색합니다.
+     *
+     * @param query 검색할 쿼리
+     * @return VWorldSearchApiResponse 포인트 검색 결과를 담고 있는 응답 객체
+     */
+    public VWorldSearchApiResponse getPoint(String query) {
+        log.info("query: {}", query);
+        checkEmpty(query);
+
+        var response = vWorldSearchApiClient.getPoint(
+                VWorldSearchApiRequest.builder()
+                        .key(API_KEY_VWORLD)
+                        .query(query)
+                        .build());
+
+        return response;
+    }
+
+    /**
+     * 주어진 쿼리와 페이지 번호로 포인트를 검색합니다.
+     *
+     * @param query 검색할 쿼리
+     * @param page 검색할 현재 페이지 번호
+     * @return VWorldSearchApiResponse 포인트 검색 결과를 담고 있는 응답 객체
+     */
+    public VWorldSearchApiResponse getPointWithPage(String query, Integer page) {
+        log.info("query: {}, page: {}", query, page);
+        checkEmpty(query);
+
+        var response = vWorldSearchApiClient.getPoint(
+                VWorldSearchApiRequest.builder()
+                        .key(API_KEY_VWORLD)
+                        .query(query)
+                        .page(page)
+                        .build());
+
+        return response;
+    }
+
+    /**
+     * 입력 쿼리가 빈 값인지 확인하고 예외를 던집니다.
+     *
+     * @param query 확인할 쿼리
+     */
+    private static void checkEmpty(String query) {
+        if (query == null || query.trim().isEmpty()) {
+            String errorMessage = "검색이 불가능합니다:: 키워드가 빈 값입니다.";
+            log.error(errorMessage);
+            throw new EmptyInputException(errorMessage);
+        }
     }
 }

--- a/backend/src/main/java/com/jsj/backend/search/SearchService.java
+++ b/backend/src/main/java/com/jsj/backend/search/SearchService.java
@@ -119,6 +119,8 @@ public class SearchService {
                         .query(query)
                         .build());
 
+        logVWorldSearchApiResponse(query, response);
+
         return response;
     }
 
@@ -140,6 +142,8 @@ public class SearchService {
                         .page(page)
                         .build());
 
+        logVWorldSearchApiResponse(query, response);
+
         return response;
     }
 
@@ -154,5 +158,26 @@ public class SearchService {
             log.error(errorMessage);
             throw new EmptyInputException(errorMessage);
         }
+    }
+
+    /**
+     * VWorld 검색 API 응답을 로깅하고 로그 저장소에 저장합니다.
+     *
+     * @param query 검색한 쿼리
+     * @param response VWorldSearchApiResponse 응답 객체
+     */
+    private void logVWorldSearchApiResponse(String query, VWorldSearchApiResponse response) {
+        String errorCode = null;
+        String errorText = null;
+        if (response.getResponse().getError() != null) {
+            errorCode = response.getResponse().getError().getCode();
+            errorText = response.getResponse().getError().getText();
+        }
+        vWorldLogRepository.save(VWorldLog.builder()
+                .searchQuery(query)
+                .status(response.getResponse().getStatus())
+                .errorCode(errorCode)
+                .errorText(errorText)
+                .build());
     }
 }

--- a/backend/src/main/java/com/jsj/backend/search/vworld/SpatialReferenceSystem.java
+++ b/backend/src/main/java/com/jsj/backend/search/vworld/SpatialReferenceSystem.java
@@ -1,0 +1,86 @@
+package com.jsj.backend.search.vworld;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 좌표계를 나타내는 열거형 클래스
+ */
+@Getter
+@AllArgsConstructor
+public enum SpatialReferenceSystem {
+    /**
+     * WGS84 경위도 (EPSG:4326)
+     */
+    WGS84("EPSG:4326"),
+
+    /**
+     * GRS80 경위도 (EPSG:4019)
+     */
+    GRS80("EPSG:4019"),
+
+    /**
+     * Google Mercator (EPSG:3857)
+     */
+    GOOGLE_MERCATOR_3857("EPSG:3857"),
+
+    /**
+     * Google Mercator (EPSG:900913)
+     */
+    GOOGLE_MERCATOR_900913("EPSG:900913"),
+
+    /**
+     * 서부원점 (GRS80) (EPSG:5180, 50만)
+     */
+    WESTERN_ORIGIN_5180("EPSG:5180"),
+
+    /**
+     * 서부원점 (GRS80) (EPSG:5185)
+     */
+    WESTERN_ORIGIN_5185("EPSG:5185"),
+
+    /**
+     * 중부원점 (GRS80) (EPSG:5181, 50만)
+     */
+    CENTRAL_ORIGIN_5181("EPSG:5181"),
+
+    /**
+     * 중부원점 (GRS80) (EPSG:5186)
+     */
+    CENTRAL_ORIGIN_5186("EPSG:5186"),
+
+    /**
+     * 제주원점 (GRS80, 55만) (EPSG:5182)
+     */
+    JEJU_ORIGIN_5182("EPSG:5182"),
+
+    /**
+     * 동부원점 (GRS80) (EPSG:5183, 50만)
+     */
+    EASTERN_ORIGIN_5183("EPSG:5183"),
+
+    /**
+     * 동부원점 (GRS80) (EPSG:5187)
+     */
+    EASTERN_ORIGIN_5187("EPSG:5187"),
+
+    /**
+     * 동해(울릉)원점 (GRS80) (EPSG:5184, 50만)
+     */
+    DONGHAE_ULLEUNG_ORIGIN_5184("EPSG:5184"),
+
+    /**
+     * 동해(울릉)원점 (GRS80) (EPSG:5188)
+     */
+    DONGHAE_ULLEUNG_ORIGIN_5188("EPSG:5188"),
+
+    /**
+     * UTM-K (GRS80) (EPSG:5179)
+     */
+    UTM_K("EPSG:5179");
+
+    /**
+     * 좌표계 코드
+     */
+    private final String code;
+}

--- a/backend/src/main/java/com/jsj/backend/search/vworld/VWorldLog.java
+++ b/backend/src/main/java/com/jsj/backend/search/vworld/VWorldLog.java
@@ -1,0 +1,49 @@
+package com.jsj.backend.search.vworld;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.LocalDateTime;
+
+/**
+ * VWorld API 요청 및 응답 로그를 나타내는 클래스.
+ * 이 클래스는 VWorld API에 대한 요청과 그 응답을 기록합니다.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class VWorldLog {
+    @Id
+    @GeneratedValue
+    private Long id;
+    /**
+     * 사용자 입력값
+     */
+    private String searchQuery;
+    /**
+     * 요청 상태,
+     * 예: OK, NOT_FOUND, ERROR)
+     */
+    private String status;
+    /**
+     * 오류 코드 (있을 경우)
+     */
+    private String errorCode;
+    /**
+     * 오류 메시지 (있을 경우)
+     */
+    private String errorText;
+    /**
+     * 로그 생성 시간
+     */
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/jsj/backend/search/vworld/VWorldLogRepository.java
+++ b/backend/src/main/java/com/jsj/backend/search/vworld/VWorldLogRepository.java
@@ -1,0 +1,8 @@
+package com.jsj.backend.search.vworld;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VWorldLogRepository extends JpaRepository<VWorldLog, Long> {
+}

--- a/backend/src/main/java/com/jsj/backend/search/vworld/VWorldSearchApiClient.java
+++ b/backend/src/main/java/com/jsj/backend/search/vworld/VWorldSearchApiClient.java
@@ -1,0 +1,62 @@
+package com.jsj.backend.search.vworld;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * VWorld 검색 API 클라이언트 클래스.
+ * 이 클래스는 VWorld API를 호출하여 검색 요청을 처리합니다.
+ *
+ * @Component 애노테이션을 사용하여 스프링 컨텍스트에서 빈으로 관리됩니다.
+ * @RequiredArgsConstructor는 final 필드에 대한 생성자를 자동으로 생성합니다.
+ * @Slf4j는 로깅을 위한 로거를 제공합니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class VWorldSearchApiClient {
+
+    private final RestClient restClient;
+
+    /**
+     * VWorld API를 호출하여 포인트 검색 결과를 반환합니다.
+     *
+     * @param request 검색 요청 객체
+     * @return VWorldSearchApiResponse 검색 응답 객체
+     */
+    public VWorldSearchApiResponse getPoint(VWorldSearchApiRequest request) {
+
+        // URI 생성
+        URI uri = UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host("api.vworld.kr")
+                .path("/req/search")
+                .queryParam("service", request.getService())
+                .queryParam("request", request.getRequest())
+                .queryParam("version", request.getVersion())
+                .queryParam("crs", request.getCrs())
+                .queryParam("size", request.getSize())
+                .queryParam("page", request.getPage())
+                .queryParam("query", request.getQuery())
+                .queryParam("type", request.getType())
+                .queryParam("category", request.getCategory())
+                .queryParam("format", request.getFormat())
+                .queryParam("errorformat", request.getErrorFormat())
+                .queryParam("key", request.getKey())
+                .build()
+                .toUri();
+
+        log.info("Request URI: {}", uri);
+
+        // REST API 호출 및 응답 반환
+        return restClient.get()
+                .uri(uri)
+                .retrieve()
+                .body(VWorldSearchApiResponse.class);
+    }
+}

--- a/backend/src/main/java/com/jsj/backend/search/vworld/VWorldSearchApiRequest.java
+++ b/backend/src/main/java/com/jsj/backend/search/vworld/VWorldSearchApiRequest.java
@@ -1,0 +1,114 @@
+package com.jsj.backend.search.vworld;
+
+import lombok.*;
+
+import static com.jsj.backend.search.vworld.SpatialReferenceSystem.WGS84;
+
+/**
+ * VWorld Search API 요청을 위한 DTO 클래스.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class VWorldSearchApiRequest {
+
+    /**
+     * 요청 서비스명 (기본값: "search")
+     * 필수 여부: O (선택)
+     */
+    @Builder.Default
+    private String service = "search";
+
+    /**
+     * 요청 서비스 버전 (기본값: "2.0")
+     * 필수 여부: O (선택)
+     */
+    @Builder.Default
+    private String version = "2.0";
+
+    /**
+     * 요청 서비스 오퍼레이션 (기본값: "search")
+     * 필수 여부: M (필수)
+     */
+    @Builder.Default
+    private String request = "search";
+
+    /**
+     * 발급받은 API 키
+     * 필수 여부: M (필수)
+     */
+    private String key;
+
+    /**
+     * 응답 결과 포맷 (기본값: "json")
+     * 필수 여부: O (선택)
+     * 유효값: "json", "xml"
+     */
+    @Builder.Default
+    private String format = "json";
+
+    /**
+     * 에러 응답 결과 포맷, 생략 시 format 파라미터에 지정된 포맷으로 설정 (기본값: "json")
+     * 필수 여부: O (선택)
+     * 유효값: "json", "xml"
+     */
+    @Builder.Default
+    private String errorFormat = "json";
+
+    /**
+     * 한 페이지에 출력될 응답 결과 건수 (기본값: 10, 최소값: 1, 최대값: 1000)
+     * 필수 여부: O (선택)
+     */
+    @Builder.Default
+    private Integer size = 5;
+
+    /**
+     * 응답 결과 페이지 번호 (기본값: 1)
+     * 필수 여부: O (선택)
+     */
+    @Builder.Default
+    private Integer page = 1;
+
+    /**
+     * 검색 키워드 (예: 장소(건물명, 시설명, 기관/상호명 등), 주소, 행정구역, 도로명)
+     * 필수 여부: M (필수)
+     */
+    private String query;
+
+    /**
+     * 검색 대상 (PLACE: 장소, ADDRESS: 주소, DISTRICT: 행정구역, ROAD: 도로명)
+     * 필수 여부: M (필수)
+     */
+    @Builder.Default
+    private String type = "address";
+
+    /**
+     * 검색 대상에 따른 하위 유형
+     * - 장소: O (선택)
+     * - 주소: M (필수) road: 도로명, parcel: 지번
+     * - 행정구역: M (필수)
+     */
+    @Builder.Default
+    private String category = "road";
+
+    /**
+     * 검색 영역 내의 대상만 검색 (포맷: minx,miny,maxx,maxy)
+     * 필수 여부: O (선택)
+     */
+    private String bbox;
+
+    /**
+     * 응답 결과 좌표계 (기본값: "EPSG:4326")
+     * 필수 여부: O (선택)
+     */
+    @Builder.Default
+    private String crs = WGS84.getCode();
+
+    /**
+     * format 값이 "json"일 경우 callback 함수를 지원합니다.
+     * 필수 여부: O (선택)
+     */
+    private String callback;
+}

--- a/backend/src/main/java/com/jsj/backend/search/vworld/VWorldSearchApiResponse.java
+++ b/backend/src/main/java/com/jsj/backend/search/vworld/VWorldSearchApiResponse.java
@@ -1,0 +1,232 @@
+package com.jsj.backend.search.vworld;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * VWorld 검색 API의 응답을 나타내는 클래스.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class VWorldSearchApiResponse {
+
+    /**
+     * 응답 정보를 담고 있는 루트 객체
+     */
+    private Response response;
+
+    /**
+     * 응답의 상세 정보를 담고 있는 내부 클래스.
+     */
+    @Data
+    @NoArgsConstructor
+    public static class Response {
+        /**
+         * 요청 서비스 정보
+         */
+        private Service service;
+
+        /**
+         * 처리 결과의 상태 표시 (유효값: OK, NOT_FOUND, ERROR)
+         */
+        private String status;
+
+        /**
+         * 응답결과 건수 정보
+         */
+        private Record record;
+
+        /**
+         * 응답결과 페이지 정보
+         */
+        private Page page;
+
+        /**
+         * 응답결과 루트
+         */
+        private Result result;
+
+        /**
+         * 에러 정보.
+         */
+        private Error error;
+
+        /**
+         * 서비스 정보를 담고 있는 내부 클래스.
+         */
+        @Data
+        @NoArgsConstructor
+        public static class Service {
+            /**
+             * 요청 서비스명
+             */
+            private String name;
+
+            /**
+             * 요청 서비스 버전
+             */
+            private String version;
+
+            /**
+             * 요청 서비스 오퍼레이션 이름
+             */
+            private String operation;
+
+            /**
+             * 응답결과 생성 시간
+             */
+            private String time;
+        }
+
+        /**
+         * 레코드 정보를 담고 있는 내부 클래스.
+         */
+        @Data
+        @NoArgsConstructor
+        public static class Record {
+            /**
+             * 전체 결과 건수
+             */
+            private Integer total;
+
+            /**
+             * 현재 반환된 결과 건수
+             */
+            private Integer current;
+        }
+
+        /**
+         * 페이지 정보를 담고 있는 내부 클래스.
+         */
+        @Data
+        @NoArgsConstructor
+        public static class Page {
+            /**
+             * 전체 페이지 수
+             */
+            private Integer total;
+
+            /**
+             * 현재 페이지 번호
+             */
+            private Integer current;
+
+            /**
+             * 페이지 당 반환되는 결과 건수
+             */
+            private Integer size;
+        }
+
+        /**
+         * 결과 정보를 담고 있는 내부 클래스.
+         */
+        @Data
+        @NoArgsConstructor
+        public static class Result {
+            /**
+             * 응답결과 좌표계
+             */
+            private String crs;
+
+            /**
+             * 요청 검색 대상
+             */
+            private String type;
+
+            /**
+             * 응답결과 목록
+             */
+            private List<Item> items;
+
+            /**
+             * 응답결과 상세정보, 여러 건일 경우 반복
+             */
+            @Data
+            @NoArgsConstructor
+            public static class Item {
+                /**
+                 * 주소의 ID (PNU 지번 코드)
+                 */
+                private String id;
+
+                /**
+                 * 주소 정보
+                 */
+                private Address address;
+
+                /**
+                 * 주소 좌표
+                 */
+                private Point point;
+
+                /**
+                 * 주소 정보를 담고 있는 내부 클래스.
+                 */
+                @Data
+                @NoArgsConstructor
+                public static class Address {
+                    /**
+                     * 우편번호
+                     */
+                    private Integer zipcode;
+
+                    /**
+                     * 요청한 주소의 유형
+                     */
+                    private String category;
+
+                    /**
+                     * 도로 주소
+                     */
+                    private String road;
+
+                    /**
+                     * 지번 주소
+                     */
+                    private String parcel;
+                }
+
+                /**
+                 * 좌표 정보를 담고 있는 내부 클래스.
+                 */
+                @Data
+                @NoArgsConstructor
+                public static class Point {
+                    /**
+                     * x 좌표
+                     */
+                    private String x;
+
+                    /**
+                     * y 좌표
+                     */
+                    private String y;
+                }
+            }
+        }
+
+        /**
+         * 에러 정보를 담고 있는 내부 클래스.
+         */
+        @Data
+        @NoArgsConstructor
+        public static class Error {
+            /**
+             * 에러 레벨
+             */
+            private int level;
+            /**
+             * 에러 코드
+             */
+            private String code;
+            /**
+             * 에러 메시지
+             */
+            private String text;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgis/postgis:13-3.1
+    container_name: gis_postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: gis
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - geoserver-net
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: gis_pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    networks:
+      - geoserver-net
+
+networks:
+  geoserver-net:
+    driver: bridge
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## 연관된 이슈

> #7 

## 작업 내용

> VWorld API 연동
RestClient, DTO, 로직, 로그 테이블 추가
PostGIS 연동
DB 의존성 재활성화
`implementation 'org.springframework.boot:spring-boot-starter-data-jpa'`
`runtimeOnly 'org.postgresql:postgresql'`
DB 의존성 추가(postGIS)
`implementation 'org.hibernate:hibernate-spatial:6.5.2.Final'`

## 유의 사항

> VWorld 검색 API가 Juso API보다 확장된 api를 제공하는 것으로 판단됨,
Juso API 연동 개발을 임시 중지하고, VWorld API 연동 확장예정

> project root 경로에 docker-compose.yml 파일 생성,
docker-compose.yml 파일 경로에서 아래 명령어 입력,
`docker-compose up -d`
(postgresql, pgadmin 컨테이너 백그라운드에서 가동)

> (임시)postgresql 연결 정보
DB: gis
USER: admin
PASSWORD: admin
URL: jdbc:postgresql://localhost:5432/gis

> (임시)pgadmin 연결 정보
Email: admin@admin.com
password: admin
서버 생성
이름: RNA_GIS
호스트이름/주소: host.docker.internal
포트: 5432
접속 데이터베이스: gis
사용자 이름: admin
비밀번호: admin