### PR TITLE
#33 - fe-be 컨테이너화

### DIFF
--- a/backend/src/main/java/com/jsj/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/jsj/backend/config/WebConfig.java
@@ -35,8 +35,8 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedMethods("*")
-                        .allowedOrigins("http://localhost:3000");
+                        .allowedMethods("GET")
+                        .allowedOrigins("http://localhost:5173", "http://localhost:80");
             }
         };
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgis/postgis:13-3.1
     container_name: gis_postgres
     ports:
-      - "${POSTGIS_PORT}:5432"
+      - "5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -21,7 +21,7 @@ services:
     image: dpage/pgadmin4
     container_name: gis_pgadmin
     ports:
-      - "${PGADMIN_PORT}:80"
+      - "5050:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
@@ -34,18 +34,19 @@ services:
     image: docker.osgeo.org/geoserver:2.25.1
     container_name: geoserver_GIS
     ports:
-      - "${GEOSERVER_PORT}:8080"
+      - "8081:8080"
     environment:
       GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
     depends_on:
       - postgres
     networks:
       - geoserver-net
+
   backend:
     container_name: backend
-    build: backend
+    build: ./backend
     ports:
-      - "${BACKEND_PORT}:8080"
+      - "8080:8080"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -56,6 +57,19 @@ services:
       FRCN_RENT_INFO_KEY: ${FRCN_RENT_INFO_KEY}
     networks:
       - geoserver-net
+
+  frontend:
+    container_name: frontend
+    build: ./frontend
+    ports:
+      - "80:80"
+    networks:
+      - geoserver-net
+    environment:
+      VITE_BACKEND_URL: "http://backend:8080"
+      VITE_GEOSERVER_URL: "http://geoserver_GIS:8081"
+      VITE_PGADMIN_URL: "http://gis_pgadmin:5050"
+
 networks:
   geoserver-net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgis/postgis:13-3.1
     container_name: gis_postgres
     ports:
-      - "5432:5432"
+      - "${POSTGIS_PORT}:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -21,7 +21,7 @@ services:
     image: dpage/pgadmin4
     container_name: gis_pgadmin
     ports:
-      - "5050:80"
+      - "${PGADMIN_PORT}:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
@@ -34,7 +34,7 @@ services:
     image: docker.osgeo.org/geoserver:2.25.1
     container_name: geoserver_GIS
     ports:
-      - "8081:8080"
+      - "${GEOSERVER_PORT}:8080"
     environment:
       GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
     depends_on:
@@ -46,7 +46,7 @@ services:
     container_name: backend
     build: ./backend
     ports:
-      - "8080:8080"
+      - "${BACKEND_PORT}:8080"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,28 @@
+# Node.js의 공식 이미지 사용
+FROM node:20-alpine AS build
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# package.json과 package-lock.json 복사
+COPY package*.json ./
+
+# 의존성 설치
+RUN npm install
+
+# 소스 파일 복사
+COPY . .
+
+# 빌드 실행
+RUN npm run build
+
+# Nginx 사용하여 빌드된 파일을 서빙
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Nginx 설정 파일 복사
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+
+# Nginx 포트 설정
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /geoserver/ {
+        proxy_pass http://geoserver_GIS:8081/geoserver/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /pgadmin/ {
+        proxy_pass http://gis_pgadmin:5050/browser/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,10 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server: {
-    port: 3000,
-  },
+  // server: { 개발 서버 설정
+  //   host: '0.0.0.0',
+  //   port: 80,
+  //   strictPort: true,
+  // },
 })
+


### PR DESCRIPTION
## 연관된 이슈

> #33

## 작업 내용

>  fe-be 컨테이너화
Spring, GeoServer, pgAdmin, Vite docker-compose.yml 통해 컨테이너화,
동일한 네트워크로 연결,
nginx를 프록시로 사용,
nginx 파일에 vite 빌드 파일 서빙하여 포트 번호를 숨김